### PR TITLE
Feat/audit fixies

### DIFF
--- a/contracts/bridge/InceptionBridge.sol
+++ b/contracts/bridge/InceptionBridge.sol
@@ -95,6 +95,7 @@ contract InceptionBridge is
 
         emit Deposited(
             destinationChain,
+            _bridgeAddressByChainId[destinationChain],
             sender,
             receiver,
             fromToken,
@@ -139,6 +140,9 @@ contract InceptionBridge is
         if (state.contractAddress == address(0)) {
             revert InvalidContractAddress();
         }
+        if (state.destinationContract == address(this))
+            revert WrongDestinationBridge();
+
         if (_bridgeAddressByChainId[proof.chainId] != state.contractAddress) {
             revert UnknownBridge();
         }
@@ -148,7 +152,7 @@ contract InceptionBridge is
         proof.receiptHash = state.receiptHash;
         bytes32 proofHash;
         assembly {
-            proofHash := keccak256(proof, 0x100)
+            proofHash := keccak256(proof, _PROOF_LENGTH)
         }
 
         if (ECDSA.recover(proofHash, proofSignature) != _operatorAddress) {

--- a/contracts/bridge/InceptionBridge.sol
+++ b/contracts/bridge/InceptionBridge.sol
@@ -140,7 +140,7 @@ contract InceptionBridge is
         if (state.contractAddress == address(0)) {
             revert InvalidContractAddress();
         }
-        if (state.destinationContract == address(this))
+        if (state.destinationContract != address(this))
             revert WrongDestinationBridge();
 
         if (_bridgeAddressByChainId[proof.chainId] != state.contractAddress) {

--- a/contracts/bridge/InceptionBridgeStorage.sol
+++ b/contracts/bridge/InceptionBridgeStorage.sol
@@ -12,6 +12,8 @@ abstract contract InceptionBridgeStorage is
     IInceptionBridgeStorage,
     IInceptionBridgeErrors
 {
+    uint256 internal constant _PROOF_LENGTH = 0x100;
+
     uint256 internal _globalNonce;
     address internal _operatorAddress;
 
@@ -41,6 +43,7 @@ abstract contract InceptionBridgeStorage is
     address internal _previousSender;
     uint256 internal _previousDepositBlockNum;
 
+    /// @notice WARNING: Keep it up-to-date
     uint256[50 - 15] private __gap;
 
     function __initInceptionBridgeStorage(address operatorAddress) internal {

--- a/contracts/interfaces/IInceptionBridge.sol
+++ b/contracts/interfaces/IInceptionBridge.sol
@@ -45,6 +45,7 @@ interface IInceptionBridgeStorage {
 interface IInceptionBridge {
     event Deposited(
         uint256 destinationChain,
+        address indexed destinationBridge,
         address indexed sender,
         address indexed receiver,
         address fromToken,

--- a/contracts/interfaces/IInceptionBridgeErrors.sol
+++ b/contracts/interfaces/IInceptionBridgeErrors.sol
@@ -37,6 +37,8 @@ interface IInceptionBridgeErrors {
 
     error UnknownDestination();
 
+    error WrongDestinationBridge();
+
     /// non-existing-bridge
     error UnknownDestinationChain();
 

--- a/contracts/lib/EthereumVerifier.sol
+++ b/contracts/lib/EthereumVerifier.sol
@@ -107,11 +107,11 @@ library EthereumVerifier {
         {
             uint256 topicsIter = logIter;
             logIter = CallDataRLPReader.next(logIter);
-            // Must be 3 topics RLP encoded: event signature, sender, receiver
+            // Must be 4 topics RLP encoded: event signature, destinationContract, sender, receiver
             // Each topic RLP encoded is 33 bytes (0xa0[32 bytes data])
-            // Total payload: 99 bytes. Since it's list with total size bigger than 55 bytes we need 2 bytes prefix (0xf863)
-            // So total size of RLP encoded topics array must be 101
-            if (CallDataRLPReader.itemLength(topicsIter) != 101) {
+            // Total payload: 132 bytes. Since it's list with total size bigger than 55 bytes we need 2 bytes prefix (0xf863)
+            // So total size of RLP encoded topics array must be 134
+            if (CallDataRLPReader.itemLength(topicsIter) != 134) {
                 return DepositType.None;
             }
             topicsIter = CallDataRLPReader.beginIteration(topicsIter);
@@ -164,8 +164,8 @@ library EthereumVerifier {
         {
             uint256 structOffset;
             assembly {
-                // skip 5 fields: receiptHash, contractAddress, chainId, sender, receiver
-                structOffset := add(state, 0xa0)
+                // skip 6 fields: receiptHash, destinationContract, contractAddress, chainId, sender, receiver
+                structOffset := add(state, 0xc0)
                 calldatacopy(structOffset, ptr, len)
             }
         }

--- a/contracts/lib/EthereumVerifier.sol
+++ b/contracts/lib/EthereumVerifier.sol
@@ -8,7 +8,7 @@ import "../interfaces/IInceptionBridge.sol";
 library EthereumVerifier {
     bytes32 constant TOPIC_DEPOSITED =
         keccak256(
-            "Deposited(uint256,address,address,address,address,uint256,uint256,(bytes32,bytes32,uint256,address))"
+            "Deposited(uint256,address,address,address,address,address,uint256,uint256,(bytes32,bytes32,uint256,address))"
         );
 
     enum DepositType {
@@ -19,6 +19,7 @@ library EthereumVerifier {
     struct State {
         bytes32 receiptHash;
         address contractAddress;
+        address destinationContract;
         uint256 chainId;
         address sender;
         address receiver;
@@ -100,6 +101,7 @@ library EthereumVerifier {
         }
         /* topics */
         bytes32 mainTopic;
+        address destinationContract;
         address sender;
         address receiver;
         {
@@ -114,6 +116,10 @@ library EthereumVerifier {
             }
             topicsIter = CallDataRLPReader.beginIteration(topicsIter);
             mainTopic = bytes32(CallDataRLPReader.toUintStrict(topicsIter));
+            topicsIter = CallDataRLPReader.next(topicsIter);
+            destinationContract = address(
+                bytes20(uint160(CallDataRLPReader.toUintStrict(topicsIter)))
+            );
             topicsIter = CallDataRLPReader.next(topicsIter);
             sender = address(
                 bytes20(uint160(CallDataRLPReader.toUintStrict(topicsIter)))
@@ -163,6 +169,7 @@ library EthereumVerifier {
                 calldatacopy(structOffset, ptr, len)
             }
         }
+        state.destinationContract = destinationContract;
         state.contractAddress = contractAddress;
         state.sender = sender;
         state.receiver = receiver;


### PR DESCRIPTION
This pull request brings the essential fixes for the `InceptionBridge` according to the report from the audit company. In particular, the bug known as _Double spending if new bridge deployment_ has been resolved. The following changes have been made:

1. The `Deposited` event was updated with a new field, `indexed destinationBridge`.
2. Updated the `EthereumVerifier.sol` to reflect the changes in the Deposited event.
3. Added a warning note in the `BridgeStorage` contract.
4. `_PROOF_LENGTH` is now constant."